### PR TITLE
correct volumes matching and add new parameters

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    "configurations": [
+        {
+            "name": "Python Debugger: Current File with Arguments",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "args": ["--target", "svm_masson", "ora_PROD_DEV*|ora_PROD_UAT*", "--local", "--nocgs", "--debug", "--igrouptoken", "1","--igroupname", "PROD"]
+            //"args": ["--target", "svm_masson", "ora_PROD_UAT_*", "--local", "--nocgs", "--debug", "--igrouptoken", "2"]
+            //"args": ["--target", "svm_masson", "failover_ora_PROD_UAT_log", "--debug"]
+            //"args": ["--target", "jfs_dev2", "failover_ora_DRcluster*", "--debug"]
+            //"args": ["show", "--target", "svm_masson", "ora_PROD_DEV*|ora_PROD_UAT*", "--debug"]
+        },
+        {
+            "name": "Python Debugger: Current File",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/NTAPlib/createSnapshots.py
+++ b/NTAPlib/createSnapshots.py
@@ -75,7 +75,7 @@ class createSnapshots:
                 self.showDebug()
             return(False)
         else:
-            self.volumes=list(matchingvolumes.volumes.keys())
+            self.volumes=list(matchingvolumes.volumesmatch.keys())
 
         if len(self.volumes) == 0:
             self.result=1

--- a/NTAPlib/destroyVolumes.py
+++ b/NTAPlib/destroyVolumes.py
@@ -46,14 +46,14 @@ class destroyVolumes:
         allvols=getVolumes.getVolumes(self.svm,volumes=self.volume,apicaller=localapi,debug=self.debug)
         allvols.go()
 
-        if self.volume not in allvols.volumes.keys():
+        if self.volume not in allvols.volumesmatch.keys():
             self.result=1
             self.reason="Volume " + self.volume + " does not exist on SVM " + self.svm
             if self.debug & 1:
                 self.showDebug()
             return(False)
         else:
-            uuid=allvols.volumes[self.volume]['uuid']
+            uuid=allvols.volumesmatch[self.volume]['uuid']
 
         if self.debug & 1:
             userio.message("Destroying volume " + self.svm + ":" + self.volume,service=localapi + ":OP")

--- a/NTAPlib/getCGs.py
+++ b/NTAPlib/getCGs.py
@@ -177,7 +177,7 @@ class getCGs:
                         self.showDebug()
                     return(False)
                 else:
-                    self.volumes=volumes.volumes
+                    self.volumes=volumes.volumesmatch
 
             self.result=0
             return(True)

--- a/NTAPlib/getLUNs.py
+++ b/NTAPlib/getLUNs.py
@@ -85,6 +85,7 @@ class getLUNs:
                 svmuuid=record['svm']['uuid']
                 lunpath=record['name']
                 lunuuid=record['uuid']
+                lunserial=record['serial_number']
                 volname=record['location']['volume']['name']
                 voluuid=record['location']['volume']['uuid']
 
@@ -93,7 +94,8 @@ class getLUNs:
                                     'svm':{'name':svmname,'uuid':svmuuid},
                                     'state':record['status']['state'],
                                     'igroup':[],
-                                    'volume':{'uuid':voluuid,'name':volname}}
+                                    'volume':{'uuid':voluuid,'name':volname},
+                                    'serialnumber':lunserial}
 
                 if self.debug & 4:
                     userio.message("Found LUN " + str(self.luns[lunpath]) ,service=localapi + ":DATA")

--- a/NTAPlib/getSnapmirror.py
+++ b/NTAPlib/getSnapmirror.py
@@ -76,18 +76,32 @@ class getSnapmirror:
                         if pattern == '*':
                             volumematch=True
                             break
-                        elif re.findall(r'[?*.^$]',pattern):
-                            try:
-                                volpatternmatch=re.compile(pattern)
-                            except:
-                                self.result=1
-                                self.reason="Illegal volume name match"
-                                return(False)
-                        else:
-                            volpatternmatch=re.compile('^' + pattern + '$')
+                        protected_groups = {}
+                        def protect_group(match):
+                            placeholder = f"\0{len(protected_groups)}\0"
+                            protected_groups[placeholder] = match.group(0)
+                            return placeholder
 
-                        if re.findall(volpatternmatch,srcvol) or re.findall(volpatternmatch,dstvol):
-                            volumematch=True
+                        pattern = re.sub(r'\([^)]*\)', protect_group, pattern)
+                        pattern = pattern.replace('*', '.*')
+                        for placeholder, original in protected_groups.items():
+                            pattern = pattern.replace(placeholder, original)
+                        regex = re.compile(pattern)
+                        # elif re.findall(r'[?*.^$]',pattern):
+                        #     try:
+                        #         volpatternmatch=re.compile(pattern)
+                        #     except:
+                        #         self.result=1
+                        #         self.reason="Illegal volume name match"
+                        #         return(False)
+                        # else:
+                        #     volpatternmatch=re.compile('^' + pattern + '$')
+
+                        # if re.findall(volpatternmatch,srcvol) or re.findall(volpatternmatch,dstvol):
+                        #     volumematch=True
+                        #     break
+                        if re.findall(regex,srcvol) or re.findall(regex,dstvol):
+                            volumematch = True
                             break
                 else:
                     volumematch=True

--- a/NTAPlib/getSnapshots.py
+++ b/NTAPlib/getSnapshots.py
@@ -122,7 +122,7 @@ class getSnapshots:
                 self.showDebug()
             return(False)
         else:
-            self.volumes=list(matchingvolumes.volumes.keys())
+            self.volumes=list(matchingvolumes.volumesmatch.keys())
 
         if len(self.volumes) == 0:
             self.result=1
@@ -172,7 +172,7 @@ class getSnapshots:
 
         for volmatch in self.volumes:
             if volmatch not in self.snapshots.keys():
-                self.snapshots[volmatch]={'snapshots':{},'recent':{},'uuid':matchingvolumes.volumes[volmatch]['uuid']}
+                self.snapshots[volmatch]={'snapshots':{},'recent':{},'uuid':matchingvolumes.volumesmatch[volmatch]['uuid']}
             if self.debug & 1:
                 userio.message("Retrieving snapshots for " + self.svm + ":" + volmatch,service=localapi + ":OP")
             rest=doREST.doREST(self.svm,'get',self.volapi,restargs=self.volrestargs + '&volume.name=' + volmatch,debug=self.debug)

--- a/NTAPlib/splitClones.py
+++ b/NTAPlib/splitClones.py
@@ -68,11 +68,11 @@ class splitClones:
             self.stderr=matchingvolumes.stderr
             return(False)
 
-        availvols=list(matchingvolumes.volumes.keys())
+        availvols=list(matchingvolumes.volumesmatch.keys())
         splitlist=[]
         for item in self.volumes:
             if item in availvols:
-                splitlist.append((item,matchingvolumes.volumes[item]['uuid']))
+                splitlist.append((item,matchingvolumes.volumesmatch[item]['uuid']))
             else:
                 self.result=1
                 self.failed.append(item)

--- a/snapomatic.cloneSAN4DR
+++ b/snapomatic.cloneSAN4DR
@@ -16,6 +16,7 @@ from mapLUNs import mapLUNs
 import time
 import getopt
 import re
+import binascii
 
 snapomaticversion='DEV'
 
@@ -117,6 +118,7 @@ clonelist=[]
 
 userio.linefeed()
 if not myopts.local:
+    cloneprefix = "failover_"
     userio.message("Retrieving snapmirrored volumes...")
     snapmirror=getSnapmirror(svm,volumes=voltargets.keys(),debug=debug)
     if not snapmirror.go():
@@ -133,6 +135,7 @@ if not myopts.local:
         clonelist.append(volume)
     userio.message()
 else:
+    cloneprefix = "clone_"
     volumes=getVolumes(svm,volumes=voltargets.keys(),debug=debug)
     if not volumes.go():
         userio.message(volumes.reason)
@@ -295,12 +298,12 @@ userio.message("Cloning volumes...")
 clonecompleted=[]
 clonefailed=[]
 for vol in volumes2clone:
-    clone=cloneVolumes(svm,(vol,"failover_"+ vol,clonetargets[vol]['uuid']),uuid=True,split=splitclones,debug=debug)
+    clone=cloneVolumes(svm,(vol,cloneprefix + vol,clonetargets[vol]['uuid']),uuid=True,split=splitclones,debug=debug)
     if not clone.go():
         clone.showDebug()
         clonefailed.append(vol)
     else:
-        clonecompleted.append(vol + "failover_")
+        clonecompleted.append(cloneprefix + vol)
 userio.message()
 
 if not nosleep:
@@ -310,14 +313,22 @@ if not nosleep:
 
 for lun in luns2clone:
     lunpath=lun.split('/')
-    lunpath[2]='failover_' + lunpath[2]
+    lunpath[2]=cloneprefix + lunpath[2]
     lun=('/').join(lunpath)
     igroupbase=lun.split('_')[igrouptoken]
     if igroupname:
         igroup=igroupname.replace('%',igroupbase)
     else:
         igroup=igroupbase
-    userio.message("Mapping " + lun + " to igroup " + igroup)
+    matchingluns=getLUNs(svm,lun=lun,debug=debug)
+    if not matchingluns.go():
+        userio.message("Unable to retrieve LUN")
+        matchingluns.showDebug()
+        sys.exit(1)
+    else:
+        lunserialnumberascii=matchingluns.luns[lun]["serialnumber"]
+        lunserialnumberhex=str(binascii.hexlify(lunserialnumberascii.encode())).replace("b'",'').replace("'",'')
+    userio.message("Mapping " + lun + " with serial " + lunserialnumberhex + " to igroup " + igroup)
     mapping=mapLUNs(svm,lun,igroup,debug=debug)
     if not mapping.go():
         mapping.showDebug()

--- a/snapomatic.cloneSAN4DR
+++ b/snapomatic.cloneSAN4DR
@@ -9,6 +9,7 @@ sys.path.append(sys.path[0] + "/NTAPlib")
 import userio
 from getSnapmirror import getSnapmirror
 from getSnapshots import getSnapshots
+from getVolumes import getVolumes
 from getLUNs import getLUNs
 from cloneVolumes import cloneVolumes
 from mapLUNs import mapLUNs
@@ -30,6 +31,7 @@ validoptions={'target':'multistr',
               'recoverypoint':'timestamp',
               'after':'bool',
               'nocgs':'bool',
+              'local':'bool',
               'before':'bool'}
 
 requiredoptions=['target','igrouptoken']
@@ -57,6 +59,8 @@ usage="Version " + snapomaticversion + "\n" + \
       "          (split the cloned volumes)\n\n" + \
       "          [--nocgs]\n" + \
       "          (Skip CG snapshot discovery)\n\n" + \
+      "          [--local]\n" + \
+      "          (work with sources volumes, not snapmirror destination volumes)\n\n" + \
       "          [--debug]\n" + \
       "          (show debug output)\n\n" + \
       "          [--restdebug]\n" + \
@@ -109,24 +113,34 @@ igroupname=myopts.igroupname
 
 nosleep=myopts.nosleep
 
-userio.linefeed()
-userio.message("Retrieving snapmirrored volumes...")
-snapmirror=getSnapmirror(svm,volumes=voltargets.keys(),debug=debug)
-if not snapmirror.go():
-    snapmirror.showDebug()
-if len(snapmirror.snapmirrorDestinations.keys()) < 1:
-    userio.fail("No matching snapmirrored volumes detected")
-
 clonelist=[]
 
-if len(snapmirror.snapmirrorDestinations[svm]['volumes'].keys()) > 0:
-    userio.message("Found matching snapmirrored volumes")
+userio.linefeed()
+if not myopts.local:
+    userio.message("Retrieving snapmirrored volumes...")
+    snapmirror=getSnapmirror(svm,volumes=voltargets.keys(),debug=debug)
+    if not snapmirror.go():
+        snapmirror.showDebug()
+    if len(snapmirror.snapmirrorDestinations.keys()) < 1:
+        userio.fail("No matching snapmirrored volumes detected")
+
+    if len(snapmirror.snapmirrorDestinations[svm]['volumes'].keys()) > 0:
+        userio.message("Found matching snapmirrored volumes")
+    else:
+        userio.fail("No matching snapmirrored volumes detected")
+    for volume in snapmirror.snapmirrorDestinations[svm]['volumes'].keys():
+        userio.message(">> " + volume)
+        clonelist.append(volume)
+    userio.message()
 else:
-    userio.fail("No matching snapmirrored volumes detected")
-for volume in snapmirror.snapmirrorDestinations[svm]['volumes'].keys():
-    userio.message(">> " + volume)
-    clonelist.append(volume)
-userio.message()
+    volumes=getVolumes(svm,volumes=voltargets.keys(),debug=debug)
+    if not volumes.go():
+        userio.message(volumes.reason)
+        sys.exit(1)
+    for volume in volumes.volumesmatch.keys():
+        userio.message(">> " + volume)
+        clonelist.append(volume)
+    userio.message()
 
 userio.linefeed()
 userio.message("Retrieving snapshots...")
@@ -235,18 +249,34 @@ userio.message("Retrieving LUNs from current volumes...")
 for volume in clonetargets.keys():
     lunlist=[]
 
-    for volpattern in voltargets.keys():
-        if volpattern == '*':
-            volpatternmatch=re.compile('^.*.$')
-        elif re.findall(r'[?*.^$]',volpattern):
-            volpatternmatch=re.compile(volpattern)
-        else:
-            volpatternmatch=re.compile('^' + volpattern + '$')
+    # for volpattern in voltargets.keys():
+    #     if volpattern == '*':
+    #         volpatternmatch=re.compile('^.*.$')
+    #     elif re.findall(r'[?*.^$]',volpattern):
+    #         volpatternmatch=re.compile(volpattern)
+    #     else:
+    #         volpatternmatch=re.compile('^' + volpattern + '$')
 
-        if re.match(volpatternmatch,volume):
+    #     if re.match(volpatternmatch,volume):
+    #         for lun in voltargets[volpattern]:
+    #             lunlist.append("/vol/" + volume + "/" + lun)
+
+    for volpattern in voltargets.keys():
+        protected_groups = {}
+        def protect_group(match):
+            placeholder = f"\0{len(protected_groups)}\0"
+            protected_groups[placeholder] = match.group(0)
+            return placeholder
+
+        pattern = re.sub(r'\([^)]*\)', protect_group, volpattern)
+        pattern = pattern.replace('*', '.*')
+        for placeholder, original in protected_groups.items():
+            pattern = pattern.replace(placeholder, original)
+        regex = re.compile(pattern)
+        if re.search(regex,volume):
             for lun in voltargets[volpattern]:
                 lunlist.append("/vol/" + volume + "/" + lun)
-
+                
     matchingluns=getLUNs(svm,lun=lunlist,debug=debug)
     if not matchingluns.go():
         userio.message("Unable to retrieve LUN list")

--- a/snapomatic.credential
+++ b/snapomatic.credential
@@ -203,7 +203,7 @@ elif mode == "Add credential":
         proceed=True
   
     out=doREST.doREST(newmgmt,'get','/svm/svms',restargs={'name=':newname,'fields':'name,uuid'},username=newuser,password=newpasswd)
-    if not out.result == 0:
+    if not out.result == 200:
         faildata=['Unable to validate credentials for SVM ' + newname]
         faildata.append(out.reason)
         userio.fail(faildata)

--- a/snapomatic.volume
+++ b/snapomatic.volume
@@ -77,10 +77,24 @@ except:
     cg=False
 
 svm=myopts.target[0]
+voltargets={}
 if len(myopts.target) == 1:
-    volumes='*'
+    voltargets={'*':['*']}
 else:
-    volumes=myopts.target[1:]
+    for item in myopts.target[1:]:
+        pieces=item.split('/')
+        if pieces[0] not in voltargets.keys():
+            voltargets[pieces[0]] = []
+        if len(pieces) == 1:
+            voltargets[pieces[0]].append('*')
+        elif len(pieces) == 2:
+            voltargets[pieces[0]].append(pieces[1])
+        else:
+            userio.fail("Illegal format for target " + item)
+    for vol in voltargets.keys():
+        if len(voltargets[vol]) > 1 and '*' in voltargets[vol]:
+            userio.fail("Volume targets includes a volume/LUN pair and that same volume")
+
 
 if myopts.mode == 'clone':
     if not len(myopts.target) == 2:
@@ -90,9 +104,9 @@ if myopts.mode == 'clone':
 
 if myopts.mode == 'show':
     if cg:
-        volumes=getCGs(svm,volumes=volumes,debug=debug)
+        volumes=getCGs(svm,volumes=voltargets.keys(),debug=debug)
     else:
-        volumes=getVolumes(svm,volumes=volumes,debug=debug)
+        volumes=getVolumes(svm,volumes=voltargets.keys(),debug=debug)
     if not volumes.go():
         userio.message(volumes.reason)
         sys.exit(1)
@@ -117,12 +131,12 @@ if myopts.mode == 'show':
                                  ])
         else:
             grid=[['Volume','Size (GB)','Aggregate']]
-            volumelist=list(volumes.volumes.keys())
+            volumelist=list(volumes.volumesmatch.keys())
             volumelist.sort()
             for volume in volumelist:
                 grid.append([volume,
-                             str(volumes.volumes[volume]['size']/1048576),
-                             volumes.volumes[volume]['aggrs']])
+                             str(volumes.volumesmatch[volume]['size']/1048576),
+                             volumes.volumesmatch[volume]['aggrs']])
         userio.grid(grid)
 
 elif myopts.mode == 'clone':

--- a/snapomatic.volume
+++ b/snapomatic.volume
@@ -126,8 +126,8 @@ if myopts.mode == 'show':
                     grid.append([cg,
                                  parentfield,
                                  volume,
-                                 str(volumes.volumes[volume]['size']/1048576),
-                                 volumes.volumes[volume]['aggrs'],
+                                 str(volumes.volumesmatch[volume]['size']/1048576),
+                                 volumes.volumesmatch[volume]['aggrs'],
                                  ])
         else:
             grid=[['Volume','Size (GB)','Aggregate']]


### PR DESCRIPTION
Correct volume matching from getVolume and all associated call, which must use the key volumesmatch
With cloneSAN4DR, change clone prefix name in the case of local clone (not from snapmirror destination) where it will use "clone_" as prefix
During normal clone operation with cloneSAN4DR, where it works from a snapmirror destination, it will continue to use "failover_" as prefix
Display lun serial number in hex when lun is mapped
